### PR TITLE
Remove the cypress binary installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "cypress-file-upload": "^3.1.4"
   },
   "scripts": {
+    "setup-dev": "CYPRESS_INSTALL_BINARY=0 npm install",
     "start": "react-scripts start",
     "start:auth": "PORT=3001 react-scripts start",
     "start:storage": "PORT=3002 react-scripts start",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "react-scripts": "3.0.1",
     "semantic-ui-react": "^0.87.2",
     "uuid": "^3.3.2",
+    "cypress": "^3.3.1",
     "cypress-file-upload": "^3.1.4"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "react-scripts": "3.0.1",
     "semantic-ui-react": "^0.87.2",
     "uuid": "^3.3.2",
-    "cypress": "^3.3.1",
     "cypress-file-upload": "^3.1.4"
   },
   "scripts": {


### PR DESCRIPTION
When multiple sample apps are built simultaneously, the Cypress binary will be installed at the shared location, which may cause that Cypress will not be launched at test time. After checking the official doc, I decide to add `CYPRESS_INSTALL_BINARY=0` environment variable for building the sample app.